### PR TITLE
PoC: Workaround of Elasticsearch 6.4.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+version: '{build}'
+
+image: Visual Studio 2017
+
+environment:
+  DOCKER_USER:
+    secure: LJxMxZl1dCKgMF5FlErnwQ==
+  DOCKER_PASS:
+    secure: HASfuLeqW86zydzpb7/5Zg==
+  DOCKER_IMAGE_NAME: idubnori/elasticsearch:5.6.0-nanoserver-sac2016
+
+init:
+#  - ps: docker version
+#  - ps: docker info
+  - ps: docker images
+  - ps: |
+      cinst curl -y --no-progress
+      sal curl (Join-Path $env:ChocolateyInstall "bin\curl.exe") -O AllScope
+
+build_script:
+  - ps: |
+      cd $env:APPVEYOR_BUILD_FOLDER
+      cd .\elasticsearch\nanoserver\sac2016
+      docker build -t $env:DOCKER_IMAGE_NAME .
+      docker images
+
+test_script:
+  - ps: |
+      $cid = docker run -d $env:DOCKER_IMAGE_NAME
+      $hostip = docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}" $cid
+      Start-Sleep -s 15
+      curl --connect-timeout 30 -sfL "http://${hostip}:9200/_cat/health"
+
+deploy_script:
+#  - ps: |
+#      echo $env:DOCKER_PASS | docker login -u $env:DOCKER_USER --password-stdin
+#      docker push $env:DOCKER_IMAGE_NAME

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
     secure: LJxMxZl1dCKgMF5FlErnwQ==
   DOCKER_PASS:
     secure: HASfuLeqW86zydzpb7/5Zg==
-  DOCKER_IMAGE_NAME: idubnori/elasticsearch:5.6.0-nanoserver-sac2016
+  DOCKER_IMAGE_NAME: idubnori/elasticsearch:6.4.0-nanoserver-sac2016
 
 init:
 #  - ps: docker version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@ init:
 #  - ps: docker version
 #  - ps: docker info
   - ps: docker images
-  - ps: |
-      cinst curl -y --no-progress
-      sal curl (Join-Path $env:ChocolateyInstall "bin\curl.exe") -O AllScope
+#  - ps: |
+#      cinst curl -y --no-progress
+#      sal curl (Join-Path $env:ChocolateyInstall "bin\curl.exe") -O AllScope
 
 build_script:
   - ps: |
@@ -28,10 +28,18 @@ test_script:
   - ps: |
       $cid = docker run -d $env:DOCKER_IMAGE_NAME
       $hostip = docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}" $cid
-      Start-Sleep -s 15
-      curl --connect-timeout 30 -sfL "http://${hostip}:9200/_cat/health"
+      Start-Sleep -s 45
+      Write-Host "Fetching HTTP at container IP: $hostip"
+      $response = iwr -useb "http://${hostip}:9200/_cat/health"
+      $health = $response.Content.Split(' ')[3]
+      if ($response.StatusCode -eq 200 -and ($health -eq 'green' -or $health -eq 'yellow')) {
+          Write-Host "Test passed - Elasticsearch is running, health: $health"
+      } else {
+          Write-Host "Test failed"
+          exit 1
+      }
 
 deploy_script:
-#  - ps: |
-#      echo $env:DOCKER_PASS | docker login -u $env:DOCKER_USER --password-stdin
-#      docker push $env:DOCKER_IMAGE_NAME
+  - ps: |
+      echo $env:DOCKER_PASS | docker login -u $env:DOCKER_USER --password-stdin
+      docker push $env:DOCKER_IMAGE_NAME

--- a/elasticsearch/nanoserver/sac2016/Dockerfile
+++ b/elasticsearch/nanoserver/sac2016/Dockerfile
@@ -22,7 +22,7 @@ ENV ES_HOME="C:\elasticsearch" `
     ES_JAVA_OPTS="-Xms512m -Xmx512m"
 
 # Volume and drive mount
-VOLUME C:\data
+RUN mkdir c:\data\
 RUN Set-ItemProperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\data' -Type String    
    
 EXPOSE 9200 9300

--- a/elasticsearch/nanoserver/sac2016/Dockerfile
+++ b/elasticsearch/nanoserver/sac2016/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/windowsservercore:ltsc2016 AS downloader
+FROM microsoft/windowsservercore AS downloader
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG ES_VERSION="6.4.0"
@@ -23,7 +23,7 @@ ENV ES_HOME="C:\elasticsearch" `
 
 # Volume and drive mount
 RUN mkdir c:\data\
-RUN Set-ItemProperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\data' -Type String    
+#RUN Set-ItemProperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\data' -Type String    
    
 EXPOSE 9200 9300
 SHELL ["cmd", "/S", "/C"]

--- a/elasticsearch/nanoserver/sac2016/config/elasticsearch.yml
+++ b/elasticsearch/nanoserver/sac2016/config/elasticsearch.yml
@@ -5,4 +5,4 @@ network.host: 0.0.0.0
 discovery.zen.minimum_master_nodes: 1
 
 path:
-    data: g:\
+    data: c:\data\


### PR DESCRIPTION
It seems to [work well](https://ci.appveyor.com/project/idubnori/dockerfiles-windows#L164) if not use `VOLUME` in the `Dockerfile` and network drive setting.
Something file permission control changed in ES side from version 6.x?
This PR is just PoC and the information.

Hope your great Dockerfile collection will have Elasticsearch 6.4.
