### PR TITLE
Fixed wrong alias in Kibana ltsc2019 Dockerfile

### DIFF
--- a/kibana/windowsservercore/ltsc2019/Dockerfile
+++ b/kibana/windowsservercore/ltsc2019/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM mcr.microsoft.com/windows/servercore:ltsc2019 AS installer
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 AS downloader
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG KIBANA_VERSION="5.6.11"


### PR DESCRIPTION
The image couldn't build because the alias was wrong.